### PR TITLE
Add local.properties to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cashu.sqlite3
 .DS_Store
 /docs/api/
 cashuclienttests.log
+local.properties


### PR DESCRIPTION
`local.properties` is generated by Android Studio and should not be checked in.