### PR TITLE
Fix serialization of `Nut` model

### DIFF
--- a/lib/src/main/kotlin/me/tb/cashuclient/types/InfoResponse.kt
+++ b/lib/src/main/kotlin/me/tb/cashuclient/types/InfoResponse.kt
@@ -21,8 +21,14 @@ public data class InfoResponse(
 )
 
 @Serializable
+public data class Method(
+    val method: String,
+    val unit: String
+)
+
+@Serializable
 public data class Nut(
-    val methods: List<List<String>>? = null,
+    val methods: List<Method>? = null,
     val disabled: Boolean? = null,
     val supported: Boolean? = null
 )


### PR DESCRIPTION
A serialization unit test was failing with
```
Unexpected JSON token at offset 170: Expected start of the array '[', but had '[' instead at path: $.nuts['4'].methods[0]
```

because response structure is different from the one used by `Nut`.

Fix by introducing a `Method` model type as part of a `Nul` type matching actual json response structure.